### PR TITLE
Finding the correct file name when removing the cwd substring

### DIFF
--- a/console-trace.js
+++ b/console-trace.js
@@ -29,8 +29,15 @@ var callsite = require('callsite')
  * @api public
  */
 
+function getBasename(call) {
+	var fileName = call.getFileName(),
+		basename = fileName.toLowerCase().replace(process.cwd().toLowerCase() + '/', '');
+	
+	return fileName.slice(-basename.length);
+}
+
 console.traceFormat = function (call, method) {
-  var basename = call.getFileName().replace(process.cwd() + '/', '')
+  var basename = getBasename(call)
     , str = '[' + basename + ':' + call.getLineNumber() + '] '
 
   if (false === console.traceColors || tty.isatty()) {


### PR DESCRIPTION
I have normalized the strings in both getFileName() and cwd() to make sure they are being compared on an even level. 

Once finding the cwd() portion of the getFileName(), I just return the original filename with the length of the cwd sliced away.

The reason I did this, was because on OS X, it wasn't removing the proper portion of the filename because the cases of each string didn't match.
