### PR TITLE
__stack not added to global object in callsite >=1.0.0. Updated for compatibility

### DIFF
--- a/console-trace.js
+++ b/console-trace.js
@@ -40,7 +40,7 @@ module.exports = function (options) {
         arguments[0] = JSON.stringify(arguments[0], null, '  ');
       }
       var pad = (arguments[0] && !console.traceOptions.right || !isatty ? ' ' : '');
-      arguments[0] = console.traceFormat(__stack[1], name) + pad + arguments[0];
+      arguments[0] = console.traceFormat(callsite()[1], name) + pad + arguments[0];
     }
     console._trace = false;
     return fn.apply(this, arguments);


### PR DESCRIPTION
Callsite 1.0.0 does not create global __stack (rather exports a function which returns current stack when called). Small change makes module compatible.

See https://github.com/LearnBoost/console-trace/issues/14
